### PR TITLE
check if has property before getting it

### DIFF
--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -33,7 +33,6 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
-        signingConfig signingConfigs.debug
     }
     buildTypes {
         release {

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -5,9 +5,9 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 fullstory {
-    org properties.hasProperty('org') ? properties.getProperty('org') : '' // your ORG_ID
-    enabledVariants properties.hasProperty('org') ? properties.getProperty('enabledVariants') : ''// enable variants that you want FS to instrument (all)
-    server properties.hasProperty('org') ? properties.getProperty('server') : ''// optional
+    org properties.hasProperty('org') ? properties.getProperty('org') : 'YOUR_ORG' // your ORG_ID
+    enabledVariants properties.hasProperty('enabledVariants') ? properties.getProperty('enabledVariants') : 'all'// enable variants that you want FS to instrument (all)
+    server properties.hasProperty('server') ? properties.getProperty('server') : 'https://fullstory.com'// optional
 }
 
 android {

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -5,9 +5,9 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 fullstory {
-    org properties.getProperty('org') // your ORG_ID
-    enabledVariants properties.getProperty('enabledVariants') // enable variants that you want FS to instrument (all)
-    server properties.getProperty('server') // optional
+    org properties.hasProperty('org') ? properties.getProperty('org') : '' // your ORG_ID
+    enabledVariants properties.hasProperty('org') ? properties.getProperty('enabledVariants') : ''// enable variants that you want FS to instrument (all)
+    server properties.hasProperty('org') ? properties.getProperty('server') : ''// optional
 }
 
 android {

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -5,14 +5,14 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 fullstory {
-    // ORG INFO
-    if(properties.getProperty('org') == null) throw new Exception('ORG ID is null, please configure your orgnization information in local.properties')
     org properties.getProperty('org') // your ORG_ID in local.properties, or set it here directly
+    if(org == null) throw new GradleException("ORG ID can not be null")
 
     // enable variants that you want to be instrumented by FS ( default to release if not set )
-    enabledVariants properties.getProperty('enabledVariants') != null ?
-            properties.getProperty('enabledVariants') : 'release'
-
+    if(properties.getProperty('enabledVariants') != null) {
+        enabledVariants properties.getProperty('enabledVariants')
+    }
+    
     // optional, please leave as is
     if(properties.getProperty('server') != null){
         server properties.getProperty('server')
@@ -33,6 +33,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        signingConfig signingConfigs.debug
     }
     buildTypes {
         release {

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -5,9 +5,9 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 fullstory {
-    org properties.hasProperty('org') ? properties.getProperty('org') : 'YOUR_ORG' // your ORG_ID
-    enabledVariants properties.hasProperty('enabledVariants') ? properties.getProperty('enabledVariants') : 'all'// enable variants that you want FS to instrument (all)
-    server properties.hasProperty('server') ? properties.getProperty('server') : 'https://fullstory.com'// optional
+    org properties.getProperty('org') != null ? properties.getProperty('org') : 'YOUR_ORG' // your ORG_ID
+    enabledVariants properties.getProperty('enabledVariants') != null ? properties.getProperty('enabledVariants') : 'all'// enable variants that you want FS to instrument (all)
+    server (properties.getProperty('server') != null ? properties.getProperty('server') : 'https://fullstory.com')// optional
 }
 
 android {

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -5,9 +5,18 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 fullstory {
-    org properties.getProperty('org') != null ? properties.getProperty('org') : 'YOUR_ORG' // your ORG_ID
-    enabledVariants properties.getProperty('enabledVariants') != null ? properties.getProperty('enabledVariants') : 'all'// enable variants that you want FS to instrument (all)
-    server (properties.getProperty('server') != null ? properties.getProperty('server') : 'https://fullstory.com')// optional
+    // ORG INFO
+    if(properties.getProperty('org') == null) throw new Exception('ORG ID is null, please configure your orgnization information in local.properties')
+    org properties.getProperty('org') // your ORG_ID in local.properties, or set it here directly
+
+    // enable variants that you want to be instrumented by FS ( default to release if not set )
+    enabledVariants properties.getProperty('enabledVariants') != null ?
+            properties.getProperty('enabledVariants') : 'release'
+
+    // optional, please leave as is
+    if(properties.getProperty('server') != null){
+        server properties.getProperty('server')
+    }
 }
 
 android {


### PR DESCRIPTION
when user clone the project and does not add the fs properties, it threw nullpointer exception on gradle sync.
fixed by checking if exists first, if not set to empty string