### PR TITLE
log to logcat when checkout fails

### DIFF
--- a/java/app/src/main/java/com/fullstorydev/shoppedemo/utilities/FSUtils.java
+++ b/java/app/src/main/java/com/fullstorydev/shoppedemo/utilities/FSUtils.java
@@ -4,6 +4,8 @@ import com.fullstory.FS;
 import com.fullstorydev.shoppedemo.data.Item;
 import com.fullstorydev.shoppedemo.data.Order;
 
+import android.util.Log;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,9 @@ public class FSUtils{
         properties.put("order.total_real", subtotal);
 
         FS.event(EVENT_NAMES.CHECKOUT_ERROR, properties);
+
+        // log to logcat so we can generate error clicks
+        Log.e("FruitShoppe", msg);
     }
 
     public static void productUpdated(String event, Item item){


### PR DESCRIPTION
In order to properly generate error clicks, we should log an error to logcat when checkout fails.