### PR TITLE
Updated FruitShoppe Java 

### DIFF
--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'fullstory'
 
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.3"
     dataBinding {
         enabled = true
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.fullstorydev.shoppedemo"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 10
         versionName "1.0.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -3,23 +3,22 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://maven.fullstory.com" }
     }
     dependencies {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         // always ue the latest FS version
-        // DO NOT USE in production, this is for demo app purposes and can lead to unpredictable and unrepeatable builds
-        classpath 'com.fullstory:gradle-plugin-local:+'
+        classpath 'com.fullstory:gradle-plugin-local:1.19.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -28,17 +27,17 @@ task clean(type: Delete) {
 }
 
 ext {
-    room_version = "2.2.4"
-    nav_version = "2.2.1"
+    room_version = "2.3.0"
+    nav_version = "2.3.5"
     lifecycle_version = "2.2.0"
-    constraintlayout_version = "1.1.3"
-    appcompat_version = "1.1.0"
-    ext_junit_version = "1.1.1"
+    constraintlayout_version = "2.1.1"
+    appcompat_version = "1.3.1"
+    ext_junit_version = "1.1.3"
     junit_version = "4.12"
-    espresso_version = "3.2.0"
+    espresso_version = "3.4.0"
     okhttp_version = "4.4.0"
     gson_version ="2.8.6"
     glide_version = "4.11.0"
     multidex_version = "2.0.1"
-    material_version = "1.1.0"
+    material_version = "1.4.0"
 }

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Updated FruitShoppe Java

- No longer uses wild card for FullStory SDK (will coincide with update to release process) 
- Updated targetSdkVersion to 30 and matched compileSdkVersion
- Updated to mavenCentral from jCenter
- Updated Android gradle plugin from 3.5 to 7.0
- Updated gradle wrapper to use 7.0
- Updated most jetpack libraries and jUnit 