### PR TITLE
SC179660 - Added the ability to crash FruitShoppe Android App

### DIFF
--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation "com.google.code.gson:gson:$rootProject.gson_version"
     implementation "com.google.android.material:material:$rootProject.material_version"
     implementation "com.github.bumptech.glide:glide:$rootProject.glide_version"
+    implementation "io.reactivex.rxjava3:rxjava:$rootProject.rxjava_version"
+    implementation "com.jakewharton.rxbinding4:rxbinding:$rootProject.rxbinding_version"
 
     testImplementation "junit:junit:$rootProject.junit_version"
     testImplementation "androidx.room:room-testing:$rootProject.room_version"

--- a/java/app/src/main/java/com/fullstorydev/shoppedemo/ui/main/MainActivity.java
+++ b/java/app/src/main/java/com/fullstorydev/shoppedemo/ui/main/MainActivity.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
@@ -22,13 +23,21 @@ import com.fullstory.FS;
 import com.fullstory.FSOnReadyListener;
 import com.fullstory.FSSessionData;
 import com.fullstorydev.shoppedemo.R;
+import com.jakewharton.rxbinding4.view.RxView;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.rxjava3.disposables.Disposable;
+
 public class MainActivity extends AppCompatActivity implements FSOnReadyListener {
+    public static final int CLICK_COUNT_TO_CRASH = 4;
+    public static final int ONE_SECOND = 1000;
     AppBarConfiguration mAppBarConfiguration;
     NavController mNavController;
     MainViewModel mMainViewModel;
+    Disposable clickObserver;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -37,10 +46,42 @@ public class MainActivity extends AppCompatActivity implements FSOnReadyListener
 
         mMainViewModel = new ViewModelProvider(this).get(MainViewModel.class);
 
+        //setup custom title in toolbar, so that we can add easter egg for crashing app
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        TextView title = toolbar.findViewById(R.id.toolbar_title);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+        //crash app if title is clicked on 4 times
+        // within 1 sec and you're on the main fragment
+        clickObserver = RxView.clicks(title)
+                .buffer(ONE_SECOND, TimeUnit.MILLISECONDS, CLICK_COUNT_TO_CRASH)
+                .filter(list -> list.size() == CLICK_COUNT_TO_CRASH && mNavController.getCurrentDestination().getId() == R.id.navigation_market)
+                .subscribe(events -> {
+                    throw new RuntimeException("Clicked On View 4 Times, Will Crash Now, Good Job!");
+                });
+
         mNavController = Navigation.findNavController(this, R.id.nav_host_fragment);
+        mNavController.addOnDestinationChangedListener((controller, destination, arguments) -> {
+            switch (destination.getId()) {
+                case R.id.navigation_market:
+                    title.setText(getString(R.string.title_market));
+                    break;
+                case R.id.navigation_cart:
+                    title.setText(getString(R.string.title_cart));
+                    break;
+                case R.id.navigation_checkout:
+                    title.setText(getString(R.string.checkout));
+                    break;
+                default:
+                    title.setText(getString(R.string.app_name));
+                    break;
+            }
+        });
         mAppBarConfiguration = new AppBarConfiguration.Builder(
                 mNavController.getGraph())
                 .build();
+
         NavigationUI.setupActionBarWithNavController(this, mNavController, mAppBarConfiguration);
         FS.setReadyListener(this);
     }
@@ -98,5 +139,14 @@ public class MainActivity extends AppCompatActivity implements FSOnReadyListener
     public void onReady(FSSessionData sessionData) {
         String fsUrl = sessionData.getCurrentSessionURL();
         // do stuff with session URL (for example send to desired integrations, etc)
+    }
+
+    @Override
+    protected void onDestroy() {
+        if(clickObserver != null) {
+            clickObserver.dispose();
+        }
+
+        super.onDestroy();
     }
 }

--- a/java/app/src/main/res/layout/activity_main.xml
+++ b/java/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,25 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent">
+
+        <TextView
+            android:id="@+id/toolbar_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/TextAppearance.AppCompat.Widget.ActionBar.Title"
+            android:layout_gravity="start"
+            />
+
+    </androidx.appcompat.widget.Toolbar>
+    
     <fragment
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
@@ -15,7 +34,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
         app:navGraph="@navigation/mobile_navigation" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/java/app/src/main/res/layout/navbar_item_cart.xml
+++ b/java/app/src/main/res/layout/navbar_item_cart.xml
@@ -15,5 +15,7 @@
         android:id="@+id/tv_nav_item_cart_cnt"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        style="?attr/textAppearanceBody1"/>
+        style="?attr/textAppearanceBody1"
+        />
+
 </LinearLayout>

--- a/java/app/src/main/res/menu/nav_menu.xml
+++ b/java/app/src/main/res/menu/nav_menu.xml
@@ -7,4 +7,5 @@
         app:actionLayout="@layout/navbar_item_cart"
         android:title="@string/title_cart"
         app:showAsAction="always"/>
+
 </menu>

--- a/java/app/src/main/res/values/styles.xml
+++ b/java/app/src/main/res/values/styles.xml
@@ -1,15 +1,15 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimaryPink</item>
         <item name="colorOnPrimary">@color/colorIvoryPink</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDarkPink</item>
         <item name="colorAccent">@color/colorIvoryPink</item>
-
         <item name="colorPrimarySurface">@color/colorPrimaryPink</item>
         <item name="colorOnBackground">@color/colorIvoryPink</item>
+        <item name="windowActionBar">false</item>
     </style>
 
     <style name="Widget.App.Button.TextButton.IconOnly" parent="Widget.MaterialComponents.Button.TextButton">

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -9,9 +9,9 @@ buildscript {
     dependencies {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         // always ue the latest FS version
-        classpath 'com.fullstory:gradle-plugin-local:1.19.1'
+        classpath 'com.fullstory:gradle-plugin-local:1.21.0'
     }
 }
 
@@ -40,4 +40,6 @@ ext {
     glide_version = "4.11.0"
     multidex_version = "2.0.1"
     material_version = "1.4.0"
+    rxjava_version = "3.1.3"
+    rxbinding_version = "4.0.0"
 }


### PR DESCRIPTION
Added the ability for a sales engineer to crash the Android FruitShoppe demo if needed. The user would need to click on the title in the toolbar 4 times within 1 second on the main screen. 

https://user-images.githubusercontent.com/85847552/148657439-51049da7-c429-4278-8780-455c0b0d2ed0.mp4

Example Session: https://app.fullstory.com/ui/1ENq/session/6647591251566592:6647591251566592!6450107103404032 